### PR TITLE
Force PNG output

### DIFF
--- a/webkitimageqt/webkit-image.cpp
+++ b/webkitimageqt/webkit-image.cpp
@@ -44,10 +44,7 @@ public slots:
       BINARYSTDOUT
       if(f.open(stdout, QIODevice::WriteOnly|QIODevice::Unbuffered))
       {
-        if(!im.save(&f, "JPEG"))
-        {
-          im.save(&f, "PNG");
-        }
+        im.save(&f, "PNG");
       }
     }
     emit finish();


### PR DESCRIPTION
The tool is more composable and unix-y if the output is always png, for (at least) two reasons:
1. The output is predictable, and the tool can appear in pipelines that can not automatically tell a jpeg from a png
2. png is lossless. This means that the tool does one thing: it renders a snapshot of the page. If the user wants lossy compression, she can easily add that later.

Also, jpeg compression of web sites is prone to creating artefacts along sharp edges. I don't think it is a good default.
